### PR TITLE
Handle OpenJDK 18 version number

### DIFF
--- a/Logisim-Fork/src/main/java/com/cburch/logisim/Main.java
+++ b/Logisim-Fork/src/main/java/com/cburch/logisim/Main.java
@@ -26,6 +26,8 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.swing.JOptionPane;
 
@@ -44,16 +46,18 @@ public class Main {
 	/* URL for the automatic updater */
 	public static final String UPDATE_URL = "https://raw.githubusercontent.com/Logisim-Ita/Logisim/master/version.xml";
 
-	public static final double JAVA_VERSION = getVersion();
+	public static final int JAVA_MAJOR_VERSION = getMajorVersion();
 
 	// here will be saved the file in use to reopen when restarting
 	public static ArrayList<String> OpenedFiles = new ArrayList<String>();
 
 	// get the runtinme java version
-	private final static double getVersion() {
+	private final static int getMajorVersion() {
 		String version = System.getProperty("java.version");
-		byte pos = (byte) version.indexOf('.', version.indexOf('.') + 1);
-		return Double.parseDouble((pos != -1) ? version.substring(0, pos) : version);
+		Pattern pattern = Pattern.compile("^(\\d)+.*");
+		Matcher matcher = pattern.matcher(version);
+		matcher.find();
+		return Integer.parseInt(matcher.group(1));
 	}
 
 	public static void main(String[] args) throws Exception {

--- a/Logisim-Fork/src/main/java/com/cburch/logisim/gui/appear/AppearanceToolbarModel.java
+++ b/Logisim-Fork/src/main/java/com/cburch/logisim/gui/appear/AppearanceToolbarModel.java
@@ -39,7 +39,7 @@ class AppearanceToolbarModel extends AbstractToolbarModel implements PropertyCha
 
 		ArrayList<ToolbarItem> rawItems = new ArrayList<ToolbarItem>();
 		int i = 1;
-		int mask = (Main.JAVA_VERSION < 10.0) ? 128 : new Frame().getToolkit().getMenuShortcutKeyMaskEx();
+		int mask = (Main.JAVA_MAJOR_VERSION < 10) ? 128 : new Frame().getToolkit().getMenuShortcutKeyMaskEx();
 		for (AbstractTool tool : tools) {
 			tool.setCltrIndex(" (" + InputEventUtil.toKeyDisplayString(mask) + "-" + i + ")");
 			i++;

--- a/Logisim-Fork/src/main/java/com/cburch/logisim/gui/main/KeyboardToolSelection.java
+++ b/Logisim-Fork/src/main/java/com/cburch/logisim/gui/main/KeyboardToolSelection.java
@@ -26,7 +26,7 @@ public class KeyboardToolSelection extends AbstractAction {
 	public static void register(Toolbar toolbar) {
 		ActionMap amap = toolbar.getActionMap();
 		InputMap imap = toolbar.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-		int mask = (Main.JAVA_VERSION < 10.0) ? 128 : new Frame().getToolkit().getMenuShortcutKeyMaskEx();
+		int mask = (Main.JAVA_MAJOR_VERSION < 10) ? 128 : new Frame().getToolkit().getMenuShortcutKeyMaskEx();
 		for (int i = 0; i < 10; i++) {
 			KeyStroke keyStroke = KeyStroke.getKeyStroke((char) ('0' + i), mask);
 			int j = (i == 0 ? 10 : i - 1);

--- a/Logisim-Fork/src/main/java/com/cburch/logisim/gui/main/LayoutToolbarModel.java
+++ b/Logisim-Fork/src/main/java/com/cburch/logisim/gui/main/LayoutToolbarModel.java
@@ -114,7 +114,7 @@ class LayoutToolbarModel extends AbstractToolbarModel {
 			if (index <= 10) {
 				if (index == 10)
 					index = 0;
-				int mask = (Main.JAVA_VERSION < 10.0) ? 128 : frame.getToolkit().getMenuShortcutKeyMaskEx();
+				int mask = (Main.JAVA_MAJOR_VERSION < 10) ? 128 : frame.getToolkit().getMenuShortcutKeyMaskEx();
 				ret += " (" + InputEventUtil.toKeyDisplayString(mask) + "-" + index + ")";
 			}
 			return ret;

--- a/Logisim-Fork/src/main/java/com/cburch/logisim/gui/menu/MenuEdit.java
+++ b/Logisim-Fork/src/main/java/com/cburch/logisim/gui/menu/MenuEdit.java
@@ -68,7 +68,7 @@ class MenuEdit extends Menu {
 	public MenuEdit(LogisimMenuBar menubar) {
 		this.menubar = menubar;
 
-		int menuMask = (Main.JAVA_VERSION < 10.0) ? 128 : getToolkit().getMenuShortcutKeyMaskEx();
+		int menuMask = (Main.JAVA_MAJOR_VERSION < 10) ? 128 : getToolkit().getMenuShortcutKeyMaskEx();
 		undo.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Z, menuMask));
 		cut.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_X, menuMask));
 		copy.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, menuMask));

--- a/Logisim-Fork/src/main/java/com/cburch/logisim/gui/menu/MenuFile.java
+++ b/Logisim-Fork/src/main/java/com/cburch/logisim/gui/menu/MenuFile.java
@@ -40,7 +40,7 @@ class MenuFile extends Menu implements ActionListener {
 		this.menubar = menubar;
 		openRecent = new OpenRecent(menubar);
 
-		int menuMask = (Main.JAVA_VERSION < 10.0) ? 128 : getToolkit().getMenuShortcutKeyMaskEx();
+		int menuMask = (Main.JAVA_MAJOR_VERSION < 10) ? 128 : getToolkit().getMenuShortcutKeyMaskEx();
 		newi.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, menuMask));
 		open.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, menuMask));
 		close.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_W, menuMask | InputEvent.SHIFT_DOWN_MASK));

--- a/Logisim-Fork/src/main/java/com/cburch/logisim/gui/menu/MenuSimulate.java
+++ b/Logisim-Fork/src/main/java/com/cburch/logisim/gui/menu/MenuSimulate.java
@@ -241,7 +241,7 @@ class MenuSimulate extends Menu {
 		menubar.registerItem(LogisimMenuBar.TICK_ENABLE, ticksEnabled);
 		menubar.registerItem(LogisimMenuBar.TICK_STEP, tickOnce);
 
-		int menuMask = (Main.JAVA_VERSION < 10.0) ? 128 : getToolkit().getMenuShortcutKeyMaskEx();
+		int menuMask = (Main.JAVA_MAJOR_VERSION < 10) ? 128 : getToolkit().getMenuShortcutKeyMaskEx();
 		run.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_E, menuMask));
 		reset.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, menuMask));
 		step.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_I, menuMask));
@@ -336,7 +336,7 @@ class MenuSimulate extends Menu {
 		menu.removeAll();
 		menu.setEnabled(items.size() > 0);
 		boolean first = true;
-		int mask = (Main.JAVA_VERSION < 10.0) ? 128 : getToolkit().getMenuShortcutKeyMaskEx();
+		int mask = (Main.JAVA_MAJOR_VERSION < 10) ? 128 : getToolkit().getMenuShortcutKeyMaskEx();
 		for (int i = items.size() - 1; i >= 0; i--) {
 			JMenuItem item = items.get(i);
 			menu.add(item);

--- a/Logisim-Fork/src/main/java/com/cburch/logisim/util/WindowMenu.java
+++ b/Logisim-Fork/src/main/java/com/cburch/logisim/util/WindowMenu.java
@@ -84,7 +84,7 @@ public class WindowMenu extends JMenu {
 		this.owner = owner;
 		WindowMenuManager.addMenu(this);
 
-		int menuMask = (Main.JAVA_VERSION < 10.0) ? 128 : getToolkit().getMenuShortcutKeyMaskEx();
+		int menuMask = (Main.JAVA_MAJOR_VERSION < 10) ? 128 : getToolkit().getMenuShortcutKeyMaskEx();
 		minimize.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_M, menuMask));
 		close.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_W, menuMask));
 


### PR DESCRIPTION
On Ubnutu 22.04 I have openJDK 18 installed and it has a version string that confuses the detection logic.  It looks like all the comparisons were against the major version only, so I changed it to an int.

```
Exception in thread "main" java.lang.ExceptionInInitializerError
Caused by: java.lang.NumberFormatException: For input string: "18-ea"
        at java.base/jdk.internal.math.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:2054)
        at java.base/jdk.internal.math.FloatingDecimal.parseDouble(FloatingDecimal.java:110)
        at java.base/java.lang.Double.parseDouble(Double.java:651)
        at com.cburch.logisim.Main.getVersion(Main.java:56)
        at com.cburch.logisim.Main.<clinit>(Main.java:47)
```

```
john@jerick-x1-2:~/lutcomp/logisim$ java --version
openjdk 18-ea 2022-03-22
OpenJDK Runtime Environment (build 18-ea+36-Ubuntu-1)
OpenJDK 64-Bit Server VM (build 18-ea+36-Ubuntu-1, mixed mode, sharing)
```