### PR TITLE
Restore missing 'ld' pin for RAM in Separate Ports mode

### DIFF
--- a/Logisim-Fork/src/main/java/com/cburch/logisim/std/memory/Ram.java
+++ b/Logisim-Fork/src/main/java/com/cburch/logisim/std/memory/Ram.java
@@ -279,8 +279,7 @@ public class Ram extends Mem {
 		
 		if (!asynch)
 			painter.drawClock(CLK, Direction.NORTH);
-		if (!separate)
-			painter.drawPort(OE, Strings.get("ramOELabel"), Direction.SOUTH);
+		painter.drawPort(OE, Strings.get("ramOELabel"), Direction.SOUTH);
 		if (!isSimple)
 			painter.drawPort(CLR, Strings.get("ramClrLabel"), Direction.SOUTH);
 


### PR DESCRIPTION
**Related Issue**
Fixes #46

**Description of Changes**
This PR restores the `ld` (load) pin on the RAM component when the "Data Interface" attribute is set to "Separate load and store ports".

In version 2.16.1.4 (during the introduction of "Simplified Mode"), the logic to initialize and draw the `OE` (Output Enable) pin in `Ram.java` was moved inside a conditional block that only executes if ports are NOT separate (`if (!separate)`). 

However, in "Separate Ports" mode, the `OE` pin is semantically required to function as the `ld` trigger. This PR moves the `OE` pin initialization outside of that conditional block so that it is available in both "One synchronous load/store port" and "Separate load and store ports" modes.